### PR TITLE
Personal Playlist Deletion & Group playlist fix

### DIFF
--- a/soiree/app/controllers/personal/playlists_controller.rb
+++ b/soiree/app/controllers/personal/playlists_controller.rb
@@ -16,6 +16,14 @@ class Personal::PlaylistsController < ApplicationController
     @playlist = Playlist.find(params[:id])
   end
 
+  def destroy
+    playlist = Playlist.find(params['id'])
+    playlist.playlist_songs.delete_all
+    playlist.destroy
+
+    redirect_to dashboard_path
+  end
+
   private
 
   def playlist(params)

--- a/soiree/app/models/playlist.rb
+++ b/soiree/app/models/playlist.rb
@@ -57,7 +57,12 @@ class Playlist < ActiveRecord::Base
   end
 
   def spotify_create_playlist(user_auth)
+    RSpotify::authenticate(ENV['SPOTIFY_KEY'], ENV['SPOTIFY_SECRET'])
     user_auth.create_playlist!(self.name + ' - Soriee')
+  end
+
+  def spotify_delete_playlist(spotify_user, playlist)
+    spotify_user.delete_playlist!(self.name + ' - Soriee')
   end
 
 end

--- a/soiree/app/views/personal/playlists/show.html.erb
+++ b/soiree/app/views/personal/playlists/show.html.erb
@@ -1,3 +1,5 @@
+<%= link_to "Remove Playlist", personal_playlist_path(@playlist), method: :delete %>
+
 <div class="fluid-container">
   <div class="panel">
     <!-- Default panel contents -->

--- a/soiree/config/routes.rb
+++ b/soiree/config/routes.rb
@@ -10,6 +10,6 @@ Rails.application.routes.draw do
   end
 
   namespace :personal do
-    resources :playlists, only: [:new, :create, :show]
+    resources :playlists, only: [:new, :create, :show, :destroy]
   end
 end


### PR DESCRIPTION
You can now delete a personal playlist.  When deleted, the user will still need
to delete the playlist from their spotify due to api restrictions. This could
possibly be fixed via flash message indicating this.

Group playlists were not working due to bug with RSpotify client auth.
This was fixed by placing an auth request before playlist creation.
